### PR TITLE
feat: setup public Learning Log structure

### DIFF
--- a/docs/knowledge/2025-09-07-github-learning-log.md
+++ b/docs/knowledge/2025-09-07-github-learning-log.md
@@ -1,0 +1,25 @@
+# Gestione Learning Log
+
+**Data:** 2025-09-07  
+**Progetto:** Portfolio Setup  
+**Argomento:** GitHub - Gestione Learning Log  
+
+## Cosa ho imparato
+ Come strutturare un sistema ibrido di Learning Log:
+- Diario cronologico (`learning-log.md`)
+- Knowledge base con pagine singole (`/knowledge/`)
+- Indice tematico per argomenti e rogenti
+
+## Snippet
+```markdown
+- 2025-09-07   GitHub ° Gestione Learning Log – [Vai alla knowledge](docs/knowledge/2025-09-07-github-learning-log.md)
+```
+
+## Fonti
+- Documentazione GitHub Pages
+- Esperienza diretta
+
+
+## Prossimo passi
+- Aggiungere nuove voci manmano che vengono promosse
+oi - Agggiornare l’indice automaticoamente

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -1,0 +1,10 @@
+# Knowledge Base
+
+Questa sezione raccoglie le voci del Learning Log, organizzate per argoment.
+
+## Argomenti
+
+- **GitHub**
+  - [Gestione Learning Log](2025-09-07-github-learning-log.md)
+
+*)Indice iniziale, verra awgiornato automaticamente con nuove voci)*

--- a/docs/learning-log.md
+++ b/docs/learning-log.md
@@ -1,0 +1,9 @@
+# Logging Log
+
+Questo file contiene lo schma_del diario delle cose imparate.
+
+Goglo: ogni verranno agginte in ordine cronologica, ciascune con link alle pagine dentro la knowledge.
+
+Solo base per now. Levo che levo aggiungere empiti, qui, esempio: 
+
+- 2025-09-07  -  GitHub - Gestione Learning Log [Vai alla knowledge](docs/knowledge/2025-09-07-github-learning-log.md)


### PR DESCRIPTION
Questa PR introduce la struttura iniziale per il Learning Log pubblico.

### Contenuti
- `docs/learning-log.md`: diario cronologico delle voci.
- `docs/knowledge/index.md`: indice tematico organizzato per argomento.
- `docs/knowledge/2025-09-07-github-learning-log.md`: prima voce di esempio.

### DoD
- La repo contiene la struttura base per il Learning Log.
- GitHub Pages può mostrare il diario e la knowledge base.

### Checklist
- [x] Creata cartella `docs/`
- [x] Aggiunto file cronologico
- [x] Aggiunto indice knowledge base
- [x] Aggiunta prima voce di esempio