### PR TITLE
chore(ci): setup GitHub Actions for Docusaurus deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Docusaurus site to Pages
+
+on:
+  push:
+    branches: [ "main" ]
+
+permissions: 
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Build Docusaurus site
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: build
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Questa PR aggiunge un workflow GitHub Actions per il deploy automatico del sito Docusaurus su GitHub Pages.

### Contenuti
- `.github/workflows/deploy.yml`: workflow CI/CD
  - Build del sito con `npm ci && npm run build`
  - Upload della cartella `build/` come artifact
  - Deploy automatico su GitHub Pages

### DoD
- Ogni push su `main` genera e pubblica automaticamente il sito
- Homepage personalizzata e sezioni Learning Log / Knowledge saranno visibili online

### Checklist
- [x] Workflow creato
- [x] Build configurata con Node.js 18
- [x] Deploy su Pages attivo