### PR TITLE
chore: configure GitHub Pages deployment

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,8 +4,8 @@
 const config = {
   title: 'Lorenzo — Portfolio & Learning Log',
   tagline: 'Portfolio, Learning Log e Knowledge Base',
-  url: 'https://lorenzolopresti.com',
-  baseUrl: '/',
+  url: 'https://lorenzo-lo-presti.github.io',
+  baseUrl: '/lorenzo-portfolio/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
 


### PR DESCRIPTION
## Summary
- set `url` and `baseUrl` for GitHub Pages

## Testing
- `npm run build` *(fails: unresolved docs markdown links; build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bde9745bbc83298ed4e31a1d04650a