### PR TITLE
Add dark footer with social links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,33 @@ const config = {
 
 
   organizationName: 'lorenzo-lo-presti',
-  projectName: 'lorenzo-portfolio', 
+  projectName: 'lorenzo-portfolio',
+
+  themeConfig: {
+    footer: {
+      style: 'dark',
+      links: [
+        {
+          title: 'Social',
+          items: [
+            {
+              label: 'GitHub',
+              href: 'https://github.com/lorenzo-lo-presti',
+            },
+            {
+              label: 'LinkedIn',
+              href: 'https://www.linkedin.com/in/lorenzo-lo-presti/',
+            },
+            {
+              label: 'Twitter',
+              href: 'https://twitter.com/lorenzo',
+            },
+          ],
+        },
+      ],
+      copyright: `© ${new Date().getFullYear()} Lorenzo`,
+    },
+  },
 
   presets: [
     [


### PR DESCRIPTION
## Summary
- add dark footer with GitHub, LinkedIn, and Twitter links
- include dynamic copyright notice

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be0235b200832987ae9bbb89029340