### PR TITLE
Add Tailwind CSS setup with PostCSS plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,6 +28,7 @@ const config = {
       }),
     ],
   ],
+  plugins: ['docusaurus-plugin-postcss'],
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.4.1"
+    "@docusaurus/module-type-aliases": "2.4.1",
+    "autoprefixer": "^10.4.16",
+    "docusaurus-plugin-postcss": "^0.1.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1"
   },
   "overrides": {
     "undici": "5.28.3"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,8 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --ifm-color-primary: #2e8555;
 }
 
-html,
-body {
+html, body {
   font-family: system-ui, sans-serif;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './src/**/*.{js,jsx}',
+    './docs/**/*',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- configure Tailwind with class-based dark mode
- hook PostCSS plugin into Docusaurus
- replace custom stylesheet with Tailwind directives

## Testing
- `npm run build` (fails: Docusaurus was unable to resolve the "docusaurus-plugin-postcss" plugin)

------
https://chatgpt.com/codex/tasks/task_e_68be020dd09c8329a23918536743bb6d