### PR TITLE
feat: add gh-pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,40 +1,30 @@
-name: Deploy Docusaurus site to Pages
+name: Build and Deploy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
-permissions: 
-  contents: read
-  pages: write
-  id-token: write
+permissions:
+  contents: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 16
-      - name: Build
-        working-directory: .
-        run: |
-          npm install
-          npm run build
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: build
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build and deploy
+        run: npm run deploy
+        env:
+          GIT_USER: github-actions[bot]
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -19,12 +19,23 @@ Questo avvia un server di sviluppo su `http://localhost:3000`.
 
 ## Deploy
 
-- Ogni push sul branch `main` esegue il workflow GitHub Actions che costruisce e pubblica il sito su GitHub Pages.
-- Per un deploy manuale è disponibile lo script:
+### Automazione
 
-```bash
-npm run deploy
-```
+Ogni push sul branch `main` esegue il workflow GitHub Actions che costruisce il sito e lo pubblica sul branch `gh-pages` tramite il token `GITHUB_TOKEN` fornito da GitHub.
+
+### Configurazione
+
+1. Abilitare GitHub Pages dalla sezione **Pages** delle impostazioni del repo scegliendo il branch `gh-pages`.
+2. Non è necessario creare un token personale per la CI: il workflow utilizza automaticamente `secrets.GITHUB_TOKEN` con permesso `contents: write`.
+3. Per eseguire un deploy manuale da locale è necessario un token personale con permesso `repo` e impostare le variabili d'ambiente:
+
+   ```bash
+   export GIT_USER=<username>
+   export GITHUB_TOKEN=<personal-access-token>
+   npm run deploy
+   ```
+
+Lo script `npm run deploy` utilizza il branch `gh-pages` grazie alla variabile `DEPLOYMENT_BRANCH` configurata nello script.
 
 ## Dominio personalizzato
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "docusaurus build",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
-    "deploy": "docusaurus deploy"
+    "deploy": "DEPLOYMENT_BRANCH=gh-pages docusaurus deploy"
   },
   "dependencies": {
     "@docusaurus/core": "2.4.1",


### PR DESCRIPTION
## Summary
- add deploy script targeting gh-pages branch
- automate build and deployment on push to main
- document publishing steps and token setup

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be023b83408329b9cf4cd512e40bb5