### PR TITLE
Add navbar, footer, and contact page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,16 @@ const config = {
   projectName: 'lorenzo-portfolio',
 
   themeConfig: {
+    navbar: {
+      position: 'sticky',
+      items: [
+        { to: '/', label: 'Home', position: 'left' },
+        { to: '/portfolio', label: 'Portfolio', position: 'left' },
+        { to: '/docs/learning-log', label: 'Learning Log', position: 'left' },
+        { to: '/docs/knowledge/index', label: 'Knowledge Base', position: 'left' },
+        { to: '/contatti', label: 'Contatti', position: 'left' },
+      ],
+    },
     footer: {
       style: 'dark',
       links: [
@@ -23,16 +33,25 @@ const config = {
           title: 'Social',
           items: [
             {
-              label: 'GitHub',
-              href: 'https://github.com/lorenzo-lo-presti',
+              html: `
+                <a href="https://github.com/lorenzo-lo-presti" target="_blank" rel="noopener noreferrer">
+                  <img src="https://cdn.jsdelivr.net/npm/simple-icons@v8/icons/github.svg" width="24" height="24" alt="GitHub" />
+                </a>
+              `,
             },
             {
-              label: 'LinkedIn',
-              href: 'https://www.linkedin.com/in/lorenzo-lo-presti/',
+              html: `
+                <a href="https://www.linkedin.com/in/lorenzo-lo-presti/" target="_blank" rel="noopener noreferrer">
+                  <img src="https://cdn.jsdelivr.net/npm/simple-icons@v8/icons/linkedin.svg" width="24" height="24" alt="LinkedIn" />
+                </a>
+              `,
             },
             {
-              label: 'Twitter',
-              href: 'https://twitter.com/lorenzo',
+              html: `
+                <a href="https://twitter.com/lorenzo" target="_blank" rel="noopener noreferrer">
+                  <img src="https://cdn.jsdelivr.net/npm/simple-icons@v8/icons/twitter.svg" width="24" height="24" alt="Twitter" />
+                </a>
+              `,
             },
           ],
         },

--- a/src/pages/contatti.jsx
+++ b/src/pages/contatti.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function ContattiPage() {
+  return (
+    <Layout title="Contatti" description="Come mettersi in contatto">
+      <main className="container margin-vert--lg">
+        <h1>Contatti</h1>
+        <form className="max-w-lg" method="POST">
+          <div className="mb-4">
+            <label htmlFor="name" className="block mb-1">Nome</label>
+            <input type="text" id="name" name="name" required className="w-full border rounded p-2" />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="email" className="block mb-1">Email</label>
+            <input type="email" id="email" name="_replyto" required className="w-full border rounded p-2" />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="message" className="block mb-1">Messaggio</label>
+            <textarea id="message" name="message" rows="5" required className="w-full border rounded p-2" />
+          </div>
+          <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">Invia</button>
+        </form>
+        <p className="mt-6">
+          Oppure contattami via email: <a href="mailto:lorenzo@example.com">lorenzo@example.com</a>
+        </p>
+      </main>
+    </Layout>
+  );
+}


### PR DESCRIPTION
## Summary
- Add sticky navbar with links to main sections
- Define footer with social icons and copyright
- Create Contatti page with contact form

## Testing
- `npm start` *(fails: Docusaurus was unable to resolve the "docusaurus-plugin-postcss" plugin)*
- `npm run build` *(fails: Docusaurus was unable to resolve the "docusaurus-plugin-postcss" plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68be06b4a318832985958432485f8153