### PR TITLE
fix: update browserslist development targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
       "not_op_mini all"
     ],
     "development": [
-      "last 1 chrome test",
-      "last 1 firefox test",
-      "last 1 safari test"
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- use `last 1 <browser> version` in browserslist development config to avoid invalid targets

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@docusaurus%2fcore)*
- `npx browserslist` *(fails: 403 Forbidden - GET https://registry.npmjs.org/browserslist)*

------
https://chatgpt.com/codex/tasks/task_e_68be0dbdbb2c8329bb2dfe1e4aabb1e5