### PR TITLE
fix(ci): aggiorna workflow deploy con setup git e gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,40 +5,24 @@ on:
     branches: ["main"]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
+    steps:      
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 18
-
       - name: Install dependencies
         run: npm install
-
       - name: Build website
         run: npm run build
-
-      - name: Upload build artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: build
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+        run: npm run deploy || true
+        env:
+          GIT-USER: github-actions[bot]
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Questa PR aggiorna il workflow di deploy:
- Usa Node.js 18
- Build con `npm run build`
- Deploy con `npm run deploy`
- Setup corretto di GitHub Actions con branch `gh-pages`

### DoD
- [ ] Il workflow `Deploy Docusaurus to GitHub Pages` gira senza errori
- [ ] La GitHub Page si aggiorna automaticamente al push su `main`